### PR TITLE
Fix edge cases

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,16 +1,18 @@
 import { includeIgnoreFile } from '@eslint/compat';
-import js from '@eslint/js';
+import eslint from '@eslint/js';
 import prettier from 'eslint-config-prettier';
 import svelte from 'eslint-plugin-svelte';
 import globals from 'globals';
 import { fileURLToPath } from 'node:url';
-import ts from 'typescript-eslint';
+import svelteParser from 'svelte-eslint-parser';
+import tseslint from 'typescript-eslint';
+
 const gitignorePath = fileURLToPath(new URL('./.gitignore', import.meta.url));
 
-export default ts.config(
+export default tseslint.config(
 	includeIgnoreFile(gitignorePath),
-	js.configs.recommended,
-	...ts.configs.recommended,
+	eslint.configs.recommended,
+	...tseslint.configs.recommendedTypeChecked,
 	...svelte.configs['flat/recommended'],
 	prettier,
 	...svelte.configs['flat/prettier'],
@@ -19,21 +21,40 @@ export default ts.config(
 			globals: {
 				...globals.browser,
 				...globals.node
+			},
+			parser: tseslint.parser,
+			parserOptions: {
+				projectService: true,
+				tsconfigRootDir: import.meta.dirname,
+				extraFileExtensions: ['.svelte']
 			}
+		},
+		rules: {
+			'no-duplicate-imports': 'error',
+			eqeqeq: 'error',
+			'@typescript-eslint/strict-boolean-expressions': 'error',
+			'@typescript-eslint/no-unsafe-call': 'warn' // incorrectly flags {@render children?.()}
 		}
 	},
 	{
-		files: ['**/*.svelte'],
-
+		name: 'typescript',
+		files: ['**/*.ts', '*.ts']
+	},
+	{
+		name: 'svelte',
+		files: [
+			'**/*.svelte',
+			'*.svelte',
+			'**/*.svelte.js',
+			'*.svelte.js',
+			'**/*.svelte.ts',
+			'*.svelte.ts'
+		],
 		languageOptions: {
+			parser: svelteParser,
 			parserOptions: {
-				parser: ts.parser
+				parser: tseslint.parser
 			}
-		},
-
-		rules: {
-			'no-duplicate-imports': 'error',
-			eqeqeq: 'error'
 		}
 	}
 );

--- a/src/app.css
+++ b/src/app.css
@@ -7,16 +7,16 @@
 @custom-variant dark (&:is(.dark *));
 
 @theme {
-  --color-primary-50: #fff5f2;
-  --color-primary-100: #fff1ee;
-  --color-primary-200: #ffe4de;
-  --color-primary-300: #ffd5cc;
-  --color-primary-400: #ffbcad;
-  --color-primary-500: #fe795d;
-  --color-primary-600: #ef562f;
-  --color-primary-700: #eb4f27;
-  --color-primary-800: #cc4522;
-  --color-primary-900: #a5371b;
+	--color-primary-50: #fff5f2;
+	--color-primary-100: #fff1ee;
+	--color-primary-200: #ffe4de;
+	--color-primary-300: #ffd5cc;
+	--color-primary-400: #ffbcad;
+	--color-primary-500: #fe795d;
+	--color-primary-600: #ef562f;
+	--color-primary-700: #eb4f27;
+	--color-primary-800: #cc4522;
+	--color-primary-900: #a5371b;
 }
 
 /*
@@ -28,13 +28,13 @@
   color utility to any element that depends on these defaults.
 */
 @layer base {
-  *,
-  ::after,
-  ::before,
-  ::backdrop,
-  ::file-selector-button {
-    border-color: var(--color-gray-200, currentColor);
-  }
+	*,
+	::after,
+	::before,
+	::backdrop,
+	::file-selector-button {
+		border-color: var(--color-gray-200, currentColor);
+	}
 }
 
 html {

--- a/src/hooks.client.ts
+++ b/src/hooks.client.ts
@@ -14,7 +14,7 @@ interface BeforeInstallPromptEvent extends Event {
 	prompt: () => Promise<UserChoice>;
 }
 
-export const init: ClientInit = async () => {
+export const init: ClientInit = () => {
 	addEventListener('beforeinstallprompt', (e) => {
 		const event = e as BeforeInstallPromptEvent;
 

--- a/src/lib/account.svelte.ts
+++ b/src/lib/account.svelte.ts
@@ -5,10 +5,17 @@ export const acc: { studentAccount?: StudentAccount } = $state({});
 
 export const loadStudentAccount = () => {
 	const token = localStorage.getItem(LocalStorageKey.token);
+	if (token === null) return;
 
-	if (!token) return;
-
-	const { username, password, domain } = JSON.parse(token);
+	const {
+		username,
+		password,
+		domain
+	}: {
+		username: string;
+		password: string;
+		domain: string;
+	} = JSON.parse(token);
 
 	acc.studentAccount = new StudentAccount(domain, username, password);
 };

--- a/src/lib/assignments.ts
+++ b/src/lib/assignments.ts
@@ -257,14 +257,19 @@ export function getHiddenAssignmentsFromCategories(
 	pointsByCategory: PointsByCategory
 ) {
 	return categories
-		.filter(
-			(category) =>
-				pointsByCategory[category.name] &&
-				(category.pointsEarned !== pointsByCategory[category.name].pointsEarned ||
-					category.pointsPossible !== pointsByCategory[category.name].pointsPossible)
-		)
+		.filter((category) => {
+			const categoryPoints = pointsByCategory[category.name];
+			if (categoryPoints === undefined) return false;
+			return (
+				category.pointsEarned !== categoryPoints.pointsEarned ||
+				category.pointsPossible !== categoryPoints.pointsPossible
+			);
+		})
 		.map((category) => {
-			const { pointsEarned, pointsPossible } = pointsByCategory[category.name];
+			const categoryPoints = pointsByCategory[category.name];
+			if (categoryPoints === undefined) return null;
+
+			const { pointsEarned, pointsPossible } = categoryPoints;
 
 			const hiddenPointsEarned = category.pointsEarned - pointsEarned;
 			const hiddenPointsPossible = category.pointsPossible - pointsPossible;
@@ -368,6 +373,8 @@ function getAssignmentPointTotals<T extends Assignment>(assignments: Calculable<
 }
 
 export function getSynergyCourseAssignmentCategories(course: Course) {
+	if (course?.Marks === '') return undefined;
+
 	const gradeCalcSummary = course?.Marks.Mark.GradeCalculationSummary;
 
 	if (typeof gradeCalcSummary === 'string' || !gradeCalcSummary?.AssignmentGradeCalc)
@@ -508,7 +515,11 @@ export function parseSynergyAssignment(synergyAssignment: AssignmentEntity) {
 
 	let unscaledPoints: { pointsEarned: number; pointsPossible: number } | undefined = undefined;
 
-	if ((pointsEarnedIsScaled || pointsPossibleIsScaled) && _ScoreCalValue && _ScoreMaxValue) {
+	if (
+		(pointsEarnedIsScaled || pointsPossibleIsScaled) &&
+		_ScoreCalValue !== undefined &&
+		_ScoreMaxValue !== undefined
+	) {
 		unscaledPoints = {
 			pointsEarned: parseFloat(_ScoreCalValue),
 			pointsPossible: parseFloat(_ScoreMaxValue)

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -3,7 +3,7 @@ import { fileTypeFromBuffer } from 'file-type';
 import { acc } from './account.svelte';
 
 export function getColorForGrade(grade: string | number) {
-	if (typeof grade == 'number') {
+	if (typeof grade === 'number') {
 		if (grade > 100) return 'blue';
 		if (grade >= 90) return 'green';
 		else if (grade >= 80) return 'yellow';
@@ -57,7 +57,7 @@ export async function getBlobURLFromBase64String(base64: string) {
 
 	const mimeType = (await fileTypeFromBuffer(byteArray))?.mime;
 
-	if (!mimeType) throw new Error('Could not determine MIME type');
+	if (mimeType === undefined) throw new Error('Could not determine MIME type');
 
 	const blob = new Blob([byteArray], { type: mimeType });
 
@@ -66,7 +66,7 @@ export async function getBlobURLFromBase64String(base64: string) {
 
 export enum LocalStorageKey {
 	token = 'token',
-	gradebook = 'gradebook2',
+	gradebook = 'gradebook3',
 	seenAssignmentIDs = 'seenAssignmentIDs',
 	attendance = 'attendance',
 	documents = 'documents',
@@ -92,14 +92,14 @@ export const loadRecord = async <T>(
 	cacheExpirationTime: number | undefined,
 	forceRefresh = false
 ) => {
-	if ((recordState.data && !forceRefresh) || !acc.studentAccount) return;
+	if ((recordState.data !== undefined && !forceRefresh) || acc.studentAccount === undefined) return;
 
 	recordState.loaded = false;
 
 	let refresh = true;
 
 	const cacheStr = localStorage.getItem(localStorageKey);
-	if (cacheStr) {
+	if (cacheStr !== null) {
 		try {
 			const cache: LocalStorageCache<T> = JSON.parse(cacheStr);
 

--- a/src/lib/synergy.ts
+++ b/src/lib/synergy.ts
@@ -73,16 +73,16 @@ export class StudentAccount {
 		return result;
 	}
 
-	async request(methodName: string, params: unknown = {}) {
+	request(methodName: string, params: unknown = {}) {
 		return this.soapRequest('ProcessWebServiceRequest', methodName, params);
 	}
 
-	async requestMultiWeb(methodName: string, params: unknown = {}) {
+	requestMultiWeb(methodName: string, params: unknown = {}) {
 		return this.soapRequest('ProcessWebServiceRequestMultiWeb', methodName, params);
 	}
 
-	async checkLogin() {
-		await this.request('StudentInfo');
+	checkLogin() {
+		return this.request('StudentInfo').then(() => {});
 	}
 
 	async getAuthToken(): Promise<AuthToken> {

--- a/src/lib/types/Gradebook.ts
+++ b/src/lib/types/Gradebook.ts
@@ -19,7 +19,7 @@ export interface Courses {
 }
 
 export interface Course {
-	Marks: Marks;
+	Marks: Marks | '';
 	_Period: string;
 	_Title: string;
 	_CourseName: string;

--- a/src/routes/(authed)/+layout.svelte
+++ b/src/routes/(authed)/+layout.svelte
@@ -24,8 +24,11 @@
 	});
 
 	if (browser && !acc.studentAccount) {
-		if (localStorage.getItem(LocalStorageKey.token)) loadStudentAccount();
-		else goto('/login');
+		if (localStorage.getItem(LocalStorageKey.token) !== null) {
+			loadStudentAccount();
+		} else {
+			void goto('/login');
+		}
 	}
 </script>
 
@@ -37,7 +40,7 @@
 	<AppSidebar />
 </Drawer>
 
-<div class="flex h-screen flex-col md:pl-64 md:pt-0">
+<div class="flex h-screen flex-col md:pt-0 md:pl-64">
 	<div class="sticky top-0 flex items-center bg-slate-800 p-2 pr-4 md:hidden">
 		<NavHamburger
 			onClick={() => {

--- a/src/routes/(authed)/AppSidebar.svelte
+++ b/src/routes/(authed)/AppSidebar.svelte
@@ -79,7 +79,7 @@
 							<ChevronDownOutline />
 						{/if}
 					</a>
-					{#if page.params.index && currentGradebookState?.data}
+					{#if page.params.index !== undefined && currentGradebookState?.data}
 						<ul>
 							{#each currentGradebookState.data.Courses.Course as { _Title: title, _CourseID }, index (_CourseID)}
 								<li>
@@ -115,8 +115,11 @@
 		<SidebarGroup>
 			{#if $installPrompt.prompt}
 				<div transition:fade>
-					{@render sidebarLink('Install Web App', '#', DownloadOutline, () =>
-						$installPrompt.prompt?.()
+					{@render sidebarLink(
+						'Install Web App',
+						'#',
+						DownloadOutline,
+						() => void $installPrompt.prompt?.()
 					)}
 				</div>
 			{/if}

--- a/src/routes/(authed)/documents/document/+page.svelte
+++ b/src/routes/(authed)/documents/document/+page.svelte
@@ -10,7 +10,7 @@
 	let reportCardURLPromise: Promise<string> | undefined = $state();
 
 	const getReportCardURL = async (documentGU: string | null) => {
-		if (!documentGU) throw new Error('DocumentGU not provided');
+		if (documentGU === null) throw new Error('DocumentGU not provided');
 
 		if (!acc.studentAccount) throw new Error('Student account not loaded');
 

--- a/src/routes/(authed)/grades/+layout.svelte
+++ b/src/routes/(authed)/grades/+layout.svelte
@@ -14,7 +14,7 @@
 	const currentGradebookState = $derived(getCurrentGradebookState(gradebooksState));
 
 	const activeReportingPeriodName = $derived(
-		gradebooksState.records && gradebooksState.activeIndex
+		gradebooksState.records && gradebooksState.activeIndex !== undefined
 			? gradebooksState.records[gradebooksState.activeIndex]?.data?.ReportingPeriod._GradePeriod
 			: undefined
 	);
@@ -40,15 +40,15 @@
 	/>
 {/if}
 
-{#if loadingError}
+{#if loadingError !== undefined}
 	<Alert color="red" class="m-4">
 		An error occurred while loading grades: {loadingError instanceof Error
 			? loadingError.message
-			: String(loadingError)}
+			: JSON.stringify(loadingError)}
 	</Alert>
 {/if}
 
-{#if gradebooksState.overrideIndex && gradebooksState.records && gradebooksState.activeIndex && currentGradebookState?.data}
+{#if gradebooksState.overrideIndex !== undefined && gradebooksState.records && gradebooksState.activeIndex !== undefined && currentGradebookState?.data}
 	<Alert class="mx-4 flex items-center justify-between" color="light" border>
 		<span class="text-white">
 			Viewing reporting period {currentGradebookState.data.ReportingPeriod._GradePeriod}
@@ -60,4 +60,6 @@
 	</Alert>
 {/if}
 
-{@render children?.()}
+<svelte:boundary>
+	{@render children?.()}
+</svelte:boundary>

--- a/src/routes/(authed)/grades/[index]/AssignmentCard.svelte
+++ b/src/routes/(authed)/grades/[index]/AssignmentCard.svelte
@@ -78,7 +78,7 @@
 </script>
 
 <Card
-	class="flex max-w-none flex-row items-center transition duration-500 dark:text-white sm:p-4 {border}"
+	class="flex max-w-none flex-row items-center transition duration-500 sm:p-4 dark:text-white {border}"
 >
 	<div class="mr-2">
 		{#if editable}
@@ -107,7 +107,7 @@
 		{:else}
 			<span>{name}</span>
 		{/if}
-		{#if category && (!editable || categoryDropdownOptions.length === 0) && !showHypotheticalLabel}
+		{#if category !== undefined && (!editable || categoryDropdownOptions.length === 0) && !showHypotheticalLabel}
 			<Badge color={getCategoryColor(category)}>
 				{category}
 			</Badge>
@@ -157,7 +157,7 @@
 		{/if}
 	</div>
 
-	<div class="ml-auto mr-2 flex shrink-0 items-center gap-2">
+	<div class="mr-2 ml-auto flex shrink-0 items-center gap-2">
 		{#if gradePercentageChange !== undefined}
 			{#if percentageChange < 0}
 				<span class="text-red-500">
@@ -167,7 +167,7 @@
 				<span class="text-green-500">
 					+{percentageChange}%
 				</span>
-			{:else if !notForGrade && pointsEarned && !isNaN(pointsEarned)}
+			{:else if !notForGrade && pointsEarned !== undefined && !isNaN(pointsEarned)}
 				<span class="text-gray-500">+0%</span>
 			{/if}
 		{/if}

--- a/src/routes/(authed)/grades/gradebook.svelte.ts
+++ b/src/routes/(authed)/grades/gradebook.svelte.ts
@@ -4,7 +4,7 @@ import type { Gradebook, ReportPeriod } from '$lib/types/Gradebook';
 import { SvelteSet } from 'svelte/reactivity';
 
 interface GradebooksLocalStorageCache {
-	records: (undefined | LocalStorageCache<Gradebook>)[];
+	records: (null | LocalStorageCache<Gradebook>)[];
 	activeIndex: number;
 	overrideIndex?: number;
 }
@@ -35,7 +35,7 @@ const saveGradebooksState = () => {
 
 	const cache: GradebooksLocalStorageCache = {
 		records: gradebooksState.records.map((record) => {
-			if (!record || !record.data || !record.lastRefresh) return undefined;
+			if (!record || !record.data || record.lastRefresh === undefined) return null;
 
 			return { data: record.data, lastRefresh: record.lastRefresh };
 		}),
@@ -53,7 +53,7 @@ export const loadGradebooks = async () => {
 
 	// Load seen assignment ids from localStorage
 	const seenIDsStr = localStorage.getItem(LocalStorageKey.seenAssignmentIDs);
-	if (seenIDsStr) {
+	if (seenIDsStr !== null) {
 		try {
 			const seenIDs: string[] = JSON.parse(seenIDsStr);
 			seenIDs.forEach((id) => seenAssignmentIDs.add(id));
@@ -65,12 +65,12 @@ export const loadGradebooks = async () => {
 
 	// Try to load the state from the localStorage cache
 	const cacheStr = localStorage.getItem(LocalStorageKey.gradebook);
-	if (cacheStr) {
+	if (cacheStr !== null) {
 		try {
 			const cache: GradebooksLocalStorageCache = JSON.parse(cacheStr);
 
 			gradebooksState.records = cache.records.map((lsCache) => {
-				if (!lsCache) return lsCache;
+				if (lsCache === null) return undefined;
 
 				const record: RecordState<Gradebook> = {
 					data: lsCache.data,
@@ -100,7 +100,9 @@ export const loadGradebooks = async () => {
 		gradebooksState.activeIndex = activeIndex;
 
 		// Initialize the records array (will be undefined at first)
-		gradebooksState.records ??= Array(activeGradebook.ReportingPeriods.ReportPeriod.length);
+		gradebooksState.records ??= Array(activeGradebook.ReportingPeriods.ReportPeriod.length).fill(
+			undefined
+		);
 
 		// Save the active gradebook to the records array
 		gradebooksState.records[activeIndex] = {

--- a/src/routes/(authed)/mail/attachment/+page.svelte
+++ b/src/routes/(authed)/mail/attachment/+page.svelte
@@ -10,7 +10,7 @@
 	let attachmentURLPromise: Promise<string> | undefined = $state();
 
 	const getAttachmentURL = async (attachmentGU: string | null) => {
-		if (!attachmentGU) throw new Error('AttachmentGU not provided');
+		if (attachmentGU === null) throw new Error('AttachmentGU not provided');
 
 		if (!acc.studentAccount) throw new Error('Student account not loaded');
 

--- a/src/routes/(authed)/studentinfo/+page.svelte
+++ b/src/routes/(authed)/studentinfo/+page.svelte
@@ -18,15 +18,14 @@
 
 	const dataSources = Object.values(LocalStorageKey);
 
-	function copy(key: string) {
+	async function copy(key: string) {
 		const data = localStorage.getItem(key);
-
-		if (!data) {
+		if (data === null) {
 			alert('Not found');
 			return;
 		}
 
-		navigator.clipboard.writeText(data);
+		await navigator.clipboard.writeText(data);
 	}
 
 	async function paste(key: string) {
@@ -42,9 +41,7 @@
 		localStorage.setItem(key, text);
 	}
 
-	function remove(key: string) {
-		localStorage.removeItem(key);
-	}
+	const remove = (key: string) => localStorage.removeItem(key);
 </script>
 
 <svelte:head>
@@ -126,8 +123,8 @@
 					{#each dataSources as dataSource (dataSource)}
 						<TableBodyRow>
 							<TableBodyCell>{dataSource}</TableBodyCell>
-							{@render toolButton('Copy', () => copy(dataSource))}
-							{@render toolButton('Paste', () => paste(dataSource))}
+							{@render toolButton('Copy', () => void copy(dataSource))}
+							{@render toolButton('Paste', () => void paste(dataSource))}
 							{@render toolButton('Delete', () => remove(dataSource))}
 						</TableBodyRow>
 					{/each}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -10,10 +10,10 @@
 	import GithubSolid from 'flowbite-svelte-icons/GithubSolid.svelte';
 	import GridPlusOutline from 'flowbite-svelte-icons/GridPlusOutline.svelte';
 
-	if (browser && localStorage.getItem(LocalStorageKey.token)) {
+	if (browser && localStorage.getItem(LocalStorageKey.token) !== null) {
 		if (!acc.studentAccount) loadStudentAccount();
 
-		goto('/grades');
+		void goto('/grades');
 	}
 </script>
 

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -20,10 +20,10 @@
 	import InfoCircleOutline from 'flowbite-svelte-icons/InfoCircleOutline.svelte';
 	import { fly } from 'svelte/transition';
 
-	if (browser && localStorage.getItem(LocalStorageKey.token)) {
+	if (browser && localStorage.getItem(LocalStorageKey.token) !== null) {
 		if (!acc.studentAccount) loadStudentAccount();
 
-		goto('/grades');
+		void goto('/grades');
 	}
 
 	let username: string = $state('');
@@ -57,7 +57,7 @@
 
 		loggingIn = false;
 
-		goto('/grades');
+		void goto('/grades');
 	}
 </script>
 
@@ -68,7 +68,7 @@
 <LoadingBanner show={loggingIn} loadingMsg="Logging you in..." />
 
 {#if loginError}
-	<div in:fly={{ y: -50, duration: 200 }} class="fixed left-0 top-0 flex w-full justify-center p-4">
+	<div in:fly={{ y: -50, duration: 200 }} class="fixed top-0 left-0 flex w-full justify-center p-4">
 		<Alert color="red">
 			<ExclamationCircleSolid slot="icon" />
 			<span class="font-bold">Couldn't log in</span>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,8 +9,16 @@
 		"skipLibCheck": true,
 		"sourceMap": true,
 		"strict": true,
-		"moduleResolution": "bundler"
-	}
+		"moduleResolution": "bundler",
+		"noUncheckedIndexedAccess": true
+	},
+	"include": [
+		"*.js",
+		"*.ts",
+		"src/**/*.js",
+		"src/**/*.ts",
+		"src/**/*.svelte"
+	]
 	// Path aliases are handled by https://svelte.dev/docs/kit/configuration#alias
 	// except $lib which is handled by https://svelte.dev/docs/kit/configuration#files
 	//


### PR DESCRIPTION
- Fixes the eslint config to actually format svelte files and use type-aware linting. This brought up a bunch of issues that were previously missed. Also added the `strict-boolean-expressions` rule to prevent a repeat of #149. Some issues will be fixed in a later commit.
- Fixes an edge case I only just encountered where Marks can be `""`, breaking everything on the grades page
- Fixes a really-hard-to-track-down issue where `JSON.stringify()` silently converts `undefined` as well as uninitialized values in arrays to `null` when it saves the state to localStorage, but then the localStorage parsing code was only checking against `undefined`, again breaking everything on the grades page