### PR TITLE
Autofill domain with @vbstudents.com username

### DIFF
--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -40,8 +40,8 @@
 		if (loggingIn) return;
 		loggingIn = true;
 
-        if (username().includes("@vbstudents.com") {
-			username(username().replace("@vbstudents.com", "");
+        if (username().includes("@vbstudents.com")) {
+			username(username().replace("@vbstudents.com", ""));
 			domain("vbcps.studentvue.com");
 		}
 


### PR DESCRIPTION
Many students in my district struggle with logging into GradeVue because when they follow the format described in the boxes it does not allow them to log in.

This is a result of the domain being listed as an advanced option, which I think is a completely fair assessment; however, it would allow for a greater ease of access if the domain was auto-updated if certain domains were specified in the username section.

If this logic should be implemented in a separate function, that makes sense, and I can change that. I am also open to increasing the portability through a SQL database for domain corrections and the sort.

Thanks for considering my pull request, and an even BIGGER thank you for creating GradeVue.