### PR TITLE
Handle courses with multiple marks

### DIFF
--- a/docs/assignment_edge_cases.md
+++ b/docs/assignment_edge_cases.md
@@ -1,0 +1,115 @@
+# Assignment Edge Cases
+
+> [!NOTE]
+> The Score field appears to be a recent addition to StudentVUE. For some rare edge cases, we do not have data on what the expected value is.
+
+## Normal
+
+GradeCompass points earned: 3<br>
+GradeCompass points possible: 4<br>
+Included in GradeCompass grade calculations: yes
+
+- Score: "25"
+- DisplayScore: "3 out of 4"
+- ScoreCalValue: "3"
+- ScoreMaxValue: "4"
+- Points: "3 / 4"
+- Point: "3"
+- PointPossible: "4"
+
+## Scaled
+
+GradeCompass points earned: 6<br>
+GradeCompass points possible: 8<br>
+Included in GradeCompass grade calculations: yes
+
+- Score: "3"
+- DisplayScore: "3 out of 4"
+- ScoreCalValue: "3"
+- ScoreMaxValue: "4"
+- Points: "6 / 8"
+- Point: "6"
+- PointPossible: "8"
+
+## Not Graded
+
+> [!NOTE]
+> Recent example needed for when ScoreMaxValue is defined
+
+GradeCompass points earned: undefined<br>
+GradeCompass points possible: 4<br>
+Included in GradeCompass grade calculations: no
+
+- Score: undefined
+- DisplayScore: "Not Graded"
+- ScoreCalValue: undefined
+- ScoreMaxValue: "4" or undefined
+- Points: "4 Points Possible"
+- Point: undefined
+- PointPossible: undefined
+
+## Not Graded, with undefined points possible
+
+> [!NOTE]
+> Recent example needed
+
+GradeCompass points earned: undefined<br>
+GradeCompass points possible: undefined<br>
+Included in GradeCompass grade calculations: no
+
+- Score: ?
+- DisplayScore: "Not Graded"
+- ScoreCalValue: undefined
+- ScoreMaxValue: undefined
+- Points: "Points Possible"
+- Point: undefined
+- PointPossible: undefined
+
+## Zero, with empty Point
+
+> [!NOTE]
+> Recent example needed
+
+GradeCompass points earned: 0<br>
+GradeCompass points possible: 4<br>
+Included in GradeCompass grade calculations: yes
+
+- Score: ?
+- DisplayScore: "0 out of 4"
+- ScoreCalValue: "0"
+- ScoreMaxValue: "4"
+- Points: " / 4"
+- Point: ""
+- PointPossible: "4"
+
+## Extra Credit
+
+GradeCompass points earned: 3<br>
+GradeCompass points possible: shown as 4, calculated as 0<br>
+Included in GradeCompass grade calculations: yes
+
+- Score: "3"
+- DisplayScore: "3 out of 4"
+- ScoreCalValue: "3"
+- ScoreMaxValue: "4"
+- Points: "3 / "
+- Point: "3"
+- PointPossible: ""
+
+## Not For Grading
+
+> [!NOTE]
+> Recent example needed
+
+GradeCompass points earned: 3<br>
+GradeCompass points possible: 4<br>
+Included in GradeCompass grade calculations: no
+
+- Score: ?
+- DisplayScore: "3 out of 4"
+- ScoreCalValue: "3"
+- ScoreMaxValue: "4"
+- Points: "3 / 4"
+- Point: "3"
+- PointPossible: "4"
+- Notes: "(Not For Grading) "

--- a/src/lib/components/LoadingBanner.svelte
+++ b/src/lib/components/LoadingBanner.svelte
@@ -7,7 +7,7 @@
 </script>
 
 <div class="flex justify-center" in:fade out:fly={{ y: '-50%' }}>
-	<Item.Root variant="muted" size="sm" class="bg-muted/90 fixed top-6 z-10">
+	<Item.Root variant="muted" size="sm" class="bg-muted/90 fixed top-6 z-30">
 		<Item.Media><Spinner /></Item.Media>
 
 		<Item.Content>

--- a/src/lib/grades/assignments.ts
+++ b/src/lib/grades/assignments.ts
@@ -1,4 +1,4 @@
-import type { AssignmentEntity, Course } from '../types/Gradebook';
+import type { AssignmentEntity } from '../types/Gradebook';
 
 export interface Category {
 	name: string;
@@ -292,7 +292,7 @@ export function getHiddenAssignmentsFromCategories(
 			if (Math.abs(gradePercentageChange) < 0.0001) return null;
 
 			const hiddenAssignment: Flowed<HiddenAssignment> = {
-				name: `Hidden ${category.name} Assignments`,
+				name: `Point Discrepancy in ${category.name}`,
 				id: randomAssignmentID(),
 				pointsEarned: hiddenPointsEarned,
 				pointsPossible: hiddenPointsPossible,
@@ -396,26 +396,6 @@ export function getAssignmentPointTotals<T extends Assignment>(assignments: Calc
 	return { pointsEarned, pointsPossible };
 }
 
-export function getSynergyCourseAssignmentCategories(course: Course) {
-	if (course?.Marks === '') return undefined;
-
-	const gradeCalcSummary = course?.Marks.Mark.GradeCalculationSummary;
-
-	if (typeof gradeCalcSummary === 'string' || !gradeCalcSummary?.AssignmentGradeCalc)
-		return undefined;
-
-	const categories: Category[] = gradeCalcSummary.AssignmentGradeCalc.map((category) => ({
-		name: category._Type,
-		weightPercentage: parseFloat(category._Weight),
-		pointsEarned: parseFloat(category._Points),
-		pointsPossible: parseFloat(category._PointsPossible),
-		weightedPercentage: parseFloat(category._WeightedPct),
-		gradeLetter: category._CalculatedMark
-	}));
-
-	return categories;
-}
-
 export function getCalculableAssignments<T extends Assignment>(assignments: T[]) {
 	return assignments
 		.map((assignment) => {
@@ -474,65 +454,6 @@ export function parseSynergyAssignment(synergyAssignment: AssignmentEntity) {
 		_Type
 	} = synergyAssignment;
 
-	// Edge Cases:
-
-	// Normal:
-	// _Point: "3"
-	// _PointPossible: "4"
-	// _Points: "3 / 4"
-	// _ScoreCalValue: "3"
-	// _ScoreMaxValue: "4"
-	// _DisplayScore: "3 out of 4"
-
-	// Not Graded:
-	// _Point: undefined
-	// _PointPossible: undefined
-	// _Points: "4 Points Possible"
-	// _ScoreCalValue: undefined
-	// _ScoreMaxValue: "4" or undefined
-	// _DisplayScore: "Not Graded"
-
-	// Not Graded (Empty):
-	// _Point: undefined
-	// _PointPossible: undefined
-	// _Points: "Points Possible"
-	// _ScoreCalValue: undefined
-	// _ScoreMaxValue: undefined
-	// _DisplayScore: "Not Graded"
-
-	// Zero (Blank _Point):
-	// _Point: ""
-	// _PointPossible: "4"
-	// _Points: "/ 4"
-	// _ScoreCalValue: "0"
-	// _ScoreMaxValue: "4"
-	// _DisplayScore: "0 out of 4"
-
-	// Extra Credit:
-	// _Point: "3"
-	// _PointPossible: ""
-	// _Points: "3 /"
-	// _ScoreCalValue: "3"
-	// _ScoreMaxValue: "4"
-	// _DisplayScore: "3 out of 4"
-
-	// Not For Grading:
-	// _Point: "3"
-	// _PointPossible: "4"
-	// _Points: "3 / 4"
-	// _ScoreCalValue: "3"
-	// _ScoreMaxValue: "4"
-	// _DisplayScore: "3 out of 4"
-	// _Notes : "(Not For Grading)"
-
-	// Scaled:
-	// _Point: "6"
-	// _PointPossible: "8"
-	// _Points: "6 / 8"
-	// _ScoreCalValue: "3"
-	// _ScoreMaxValue: "4"
-	// _DisplayScore: "3 out of 4"
-
 	const pointsEarned = _Point !== undefined ? (_Point === '' ? 0 : parseFloat(_Point)) : undefined; // _Point can be empty; equivalent to 0
 
 	const pointsPossible =
@@ -579,7 +500,7 @@ export function parseSynergyAssignment(synergyAssignment: AssignmentEntity) {
 		unscaledPoints,
 		extraCredit: _PointPossible === '',
 		gradePercentageChange: undefined,
-		notForGrade: _Notes.includes('(Not For Grading)'),
+		notForGrade: _Notes.startsWith('(Not For Grading)'),
 		hidden: false,
 		category: _Type,
 		date: new Date(_Date),

--- a/src/lib/grades/assignments.ts
+++ b/src/lib/grades/assignments.ts
@@ -21,8 +21,9 @@ export interface Assignment {
 	hidden: boolean;
 	category: string | undefined;
 	date: Date;
-	comments?: string;
 	newHypothetical: boolean;
+	description?: string;
+	comments?: string;
 }
 
 export interface RealAssignment extends Assignment {
@@ -445,6 +446,7 @@ export function parseSynergyAssignment(synergyAssignment: AssignmentEntity) {
 	const {
 		_Date,
 		_Measure,
+		_MeasureDescription,
 		_Notes,
 		_Point,
 		_PointPossible,
@@ -490,7 +492,7 @@ export function parseSynergyAssignment(synergyAssignment: AssignmentEntity) {
 		};
 	}
 
-	const notesFormatted = _Notes.replace('(Not For Grading)', '');
+	const notesFormatted = _Notes.replace('(Not For Grading)', '').trim();
 
 	const assignment: RealAssignment = {
 		name: _Measure,
@@ -504,8 +506,9 @@ export function parseSynergyAssignment(synergyAssignment: AssignmentEntity) {
 		hidden: false,
 		category: _Type,
 		date: new Date(_Date),
-		comments: notesFormatted.length > 0 ? notesFormatted : undefined,
-		newHypothetical: false
+		newHypothetical: false,
+		description: _MeasureDescription.length > 0 ? _MeasureDescription : undefined,
+		comments: notesFormatted.length > 0 ? notesFormatted : undefined
 	};
 
 	return assignment;

--- a/src/lib/grades/catalog.svelte.ts
+++ b/src/lib/grades/catalog.svelte.ts
@@ -122,9 +122,7 @@ export async function initializeGradebookCatalog() {
 			gradebookState.gradebookCatalog.recordCache
 				.filter((record) => record !== undefined)
 				.flatMap((record) => parseGradebookXML(record.xml).Courses.Course)
-				.map((course) => course.Marks)
-				.filter((marks) => marks !== '')
-				.map((marks) => marks.Mark.Assignments.Assignment)
+				.map((course) => course.Marks?.Mark[0]?.Assignments?.Assignment)
 				.filter((assignments) => assignments !== undefined)
 				.flat()
 				.forEach((assignment) => seenAssignmentIDs.add(assignment._GradebookID));

--- a/src/lib/grades/course.ts
+++ b/src/lib/grades/course.ts
@@ -1,0 +1,36 @@
+import type { Course } from '$lib/types/Gradebook';
+import type { Category } from './assignments';
+import { seenAssignmentIDs } from './seenAssignments.svelte';
+
+const getMark = (course: Course) => course.Marks?.Mark[0];
+
+export function getCourseGrade(course: Course) {
+	const mark = getMark(course);
+	if (!mark) return;
+
+	return {
+		letter: mark._CalculatedScoreString,
+		percentage: parseFloat(mark._CalculatedScoreRaw ?? '0')
+	};
+}
+
+export const getSynergyCourseAssignmentCategories = (course: Course): Category[] | undefined =>
+	getMark(course)?.GradeCalculationSummary?.AssignmentGradeCalc.map((category) => ({
+		name: category._Type,
+		weightPercentage: parseFloat(category._Weight),
+		pointsEarned: parseFloat(category._Points),
+		pointsPossible: parseFloat(category._PointsPossible),
+		weightedPercentage: parseFloat(category._WeightedPct),
+		gradeLetter: category._CalculatedMark
+	}));
+
+export const getCourseUnseenAssignmentsCount = (course: Course) =>
+	getMark(course)?.Assignments?.Assignment.filter(
+		({ _GradebookID: id }) => !seenAssignmentIDs.has(id)
+	).length ?? 0;
+
+export function clearCourseUnseenAssignments(course: Course) {
+	getMark(course)?.Assignments?.Assignment.forEach(({ _GradebookID: id }) =>
+		seenAssignmentIDs.add(id)
+	);
+}

--- a/src/lib/types/Gradebook.ts
+++ b/src/lib/types/Gradebook.ts
@@ -175,7 +175,7 @@ export interface AssignmentEntity {
 	 * 
 	 * Starts with '(Not For Grading) ' if assignment is not for grade
 	 * 
-	 * fast-xml-parser may be removing trailing whitespace */
+	 * fast-xml-parser may be removing leading/trailing whitespace */
 	_Notes: string;
 	/** number */
 	_TeacherID: string;

--- a/src/lib/types/Gradebook.ts
+++ b/src/lib/types/Gradebook.ts
@@ -8,14 +8,15 @@ export interface Gradebook {
 	Courses: Courses;
 	'_xmlns:xsd': string;
 	'_xmlns:xsi': string;
+
 	_Type: string;
 	_ErrorMessage: string;
-	_HideStandardGraphInd: string;
-	_HideMarksColumnElementary: string;
-	_HidePointsColumnElementary: string;
-	_HidePercentSecondary: string;
-	_DisplayStandardsData: string;
-	_GBStandardsTabDefault: string;
+	_HideStandardGraphInd: boolean;
+	_HideMarksColumnElementary: boolean;
+	_HidePointsColumnElementary: boolean;
+	_HidePercentSecondary: boolean;
+	_DisplayStandardsData: boolean;
+	_GBStandardsTabDefault: boolean;
 }
 
 export interface ReportingPeriods {
@@ -23,9 +24,13 @@ export interface ReportingPeriods {
 }
 
 export interface ReportPeriod {
+	/** ex: 'Semester 2' */
 	_GradePeriod: string;
+	/** number */
 	_Index: string;
+	/** date */
 	_StartDate: string;
+	/** date */
 	_EndDate: string;
 }
 
@@ -34,101 +39,203 @@ export interface Courses {
 }
 
 export interface Course {
-	Marks: Marks | '';
+	Marks: Marks | null;
+
 	_Period: string;
+	/**```ts
+	 * `${CourseName} (${CourseID})`
+	 * ```*/
 	_Title: string;
 	_CourseName: string;
+	/** number */
 	_CourseID: string;
 	_Room: string;
+	/** Teacher name */
 	_Staff: string;
+	/** Teacher email */
 	_StaffEMail: string;
+	/** uuid */
 	_StaffGU: string;
+	/** class category associated image?
+	 * - 'arts'
+	 * - 'social'
+	 * - 'math'
+	 * - 'technical'
+	 * - 'science'
+	 * - 'language'
+	 * - 'health'
+	 */
 	_ImageType: string;
+	/** number */
 	_HighlightPercentageCutOffForProgressBar: string;
-	_UsesRichContent: string;
+	_UsesRichContent: boolean;
 }
 
 export interface Marks {
-	Mark: Mark;
+	Mark: Mark[];
 }
 
 export interface Mark {
-	StandardViews: string;
-	GradeCalculationSummary: GradeCalculationSummaryClass | string;
-	Assignments: Assignments;
-	AssignmentsSinceLastAccess: Assignments | string;
+	StandardViews: null;
+	GradeCalculationSummary: GradeCalculationSummary | null;
+	Assignments: Assignments | null;
+	AssignmentsSinceLastAccess: Assignments | null;
+
 	_MarkName: string;
 	_ShortMarkName: string;
+	/** letter grade */
 	_CalculatedScoreString: string;
+	/** number (decimal) */
 	_CalculatedScoreRaw: string;
 }
 
 export interface Assignments {
-	Assignment?: AssignmentEntity[];
+	Assignment: AssignmentEntity[];
 }
 
 export interface AssignmentEntity {
-	Resources: ResourcesClass | string;
-	Standards: string;
+	Resources: Resources | null;
+	Standards: null;
+
+	/** number */
 	_GradebookID: string;
+	/** Assignment title */
 	_Measure: string;
+	/** Assignment category */
 	_Type: string;
+	/** date */
 	_Date: string;
+	/** date */
 	_DueDate: string;
+
+	/**Unscaled points earned? More data needed
+	 * ```ts
+	 * `${number}` |
+	 * undefined // not graded
+	 * ``` */
+	_Score?: string;
+	/**
+	 * If scaled, displays unscaled points
+	 * 
+	 * a and b are numbers
+	 * ```ts
+	 * `${a} out of ${b}` |
+	 * 'Not Graded' // not graded
+	 * ```*/
 	_DisplayScore: string;
+	/**
+	 * Unscaled points earned (if scaled, otherwise usually matches Point)
+	 * ```ts
+	 * `${number}` |
+	 * undefined // not graded
+	 * ```*/
 	_ScoreCalValue?: string;
+
+	/** human-readable relative time ex: '4d' */
 	_TimeSincePost: string;
+	/** number (decimal) */
 	_TotalSecondsSincePost: string;
+
+	/**
+	 * Unscaled points possible (if scaled, otherwise usually matches PointPossible)
+	 * ```ts
+	 * `${number}` |
+	 * undefined // not graded
+	 * ```*/
 	_ScoreMaxValue?: string;
 	_ScoreType: 'Raw Score';
+	/**
+	 * If scaled, displays scaled points
+	 * 
+	 * a and b are numbers
+	 * ```ts
+	 * `${a} / ${b}` |
+	 * `${a} / ` | // extra credit
+	 * `${b} Points Possible` // not graded
+	 * ```*/
 	_Points: string;
+	/**
+	 * Scaled points earned (if scaled, otherwise usually matches ScoreCalValue)
+	 * ```ts 
+	 * `${number}` |
+	 * '' | // zero with empty point?
+	 * undefined // not graded
+	 * ```*/
 	_Point?: string;
+	/**
+	 * Scaled points possible (if scaled, otherwise usually matches ScoreMaxValue)
+	 * ```ts
+	 * `${number}` |
+	 * '' | // extra credit
+	 * undefined // not graded
+	 * ```*/
 	_PointPossible?: string;
-	_Notes: string; // Teacher comments
+
+	/** Teacher comments | ''
+	 * 
+	 * Starts with '(Not For Grading) ' if assignment is not for grade
+	 * 
+	 * fast-xml-parser may be removing trailing whitespace */
+	_Notes: string;
+	/** number */
 	_TeacherID: string;
+	/** number */
 	_StudentID: string;
+	/** Assignment description | '' */
 	_MeasureDescription: string;
-	_HasDropBox: string;
+
+	_HasDropBox: boolean;
+	/** date */
 	_DropStartDate: string;
+	/** date */
 	_DropEndDate: string;
 }
 
-export interface ResourcesClass {
-	Resource: ResourceElement[] | ResourceElement;
+export interface Resources {
+	Resource: Resource[];
 }
 
-export interface ResourceElement {
-	_Type: Type;
+export interface Resource {
+	/** ex: 'URL' */
+	_Type: string;
+	/** number */
 	_ClassID: string;
+	/** ex: 'application/vnd.google-apps.file' */
+	_FileType?: string;
+	/** number */
 	_GradebookID: string;
+	/** date (extended) */
 	_ResourceDate: Date;
+	/** same as ResourceName? */
 	_ResourceDescription: string;
+	/** number */
 	_ResourceID: string;
+	/** Resoure name (if url, title of page) */
 	_ResourceName: string;
+	/** number; order in resource list */
 	_Sequence: string;
+	/** number */
 	_TeacherID: string;
 	_url: string;
 	_ServerFileName: string;
-	_FileType?: FileType;
+	
 }
 
-export enum FileType {
-	ApplicationVndGoogleAppsFile = 'application/vnd.google-apps.file'
-}
-
-export enum Type {
-	URL = 'URL'
-}
-
-export interface GradeCalculationSummaryClass {
+export interface GradeCalculationSummary {
 	AssignmentGradeCalc: AssignmentGradeCalc[];
 }
 
 export interface AssignmentGradeCalc {
+	/** Grade category */
 	_Type: string;
+	/** 'number%' */
 	_Weight: string;
+	/** number (decimal) */
 	_Points: string;
+	/** number (decimal) */
 	_PointsPossible: string;
+	/** 'number%' */
 	_WeightedPct: string;
+	/** letter grade */
 	_CalculatedMark: string;
 }

--- a/src/routes/(authed)/AppSidebar.svelte
+++ b/src/routes/(authed)/AppSidebar.svelte
@@ -2,6 +2,7 @@
 	import { removeCourseType } from '$lib';
 	import { brand } from '$lib/brand';
 	import { buttonVariants } from '$lib/components/ui/button';
+	import Button from '$lib/components/ui/button/button.svelte';
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
 	import * as Sidebar from '$lib/components/ui/sidebar/index.js';
 	import { Spinner } from '$lib/components/ui/spinner';
@@ -117,14 +118,16 @@
 
 <Sidebar.Root>
 	<Sidebar.Header>
-		<Sidebar.Menu>
-			<Sidebar.MenuItem>
-				<div class="m-2 flex flex-row items-center">
-					<img src="/favicon.svg" class="size-6" alt={brand} />
-					<span class="ml-2 text-lg font-bold tracking-tight">{brand}</span>
-				</div>
-			</Sidebar.MenuItem>
+		<Sidebar.MenuItem>
+			<div class="m-2 flex flex-row items-center">
+				<img src="/favicon.svg" class="size-6" alt={brand} />
+				<span class="ml-2 text-lg font-bold tracking-tight">{brand}</span>
+			</div>
+		</Sidebar.MenuItem>
+	</Sidebar.Header>
 
+	<Sidebar.Content>
+		<Sidebar.Menu>
 			<Sidebar.MenuItem>
 				<Sidebar.MenuButton class="h-10 text-base">
 					{#snippet child({ props })}
@@ -165,9 +168,17 @@
 				{@render menuItem(item)}
 			{/each}
 		</Sidebar.Menu>
-	</Sidebar.Header>
 
-	<Sidebar.Content />
+		<Sidebar.MenuItem class="mt-auto mx-2">
+			<Button
+				href="/privacy"
+				variant="ghost"
+				class="text-muted-foreground h-auto border py-3 text-xs whitespace-normal"
+			>
+				Your password and grades are private and stored on-device.
+			</Button>
+		</Sidebar.MenuItem>
+	</Sidebar.Content>
 
 	<Sidebar.Footer>
 		<Sidebar.Menu class="gap-2">

--- a/src/routes/(authed)/grades/GradebookLoadingBanner.svelte
+++ b/src/routes/(authed)/grades/GradebookLoadingBanner.svelte
@@ -22,7 +22,7 @@
 	});
 </script>
 
-<Item.Root variant="muted" size="sm" class="bg-muted/90 fixed top-6 z-10">
+<Item.Root variant="muted" size="sm" class="bg-muted/90 fixed top-6 z-30">
 	<Item.Media><Spinner /></Item.Media>
 
 	<Item.Content>

--- a/src/routes/(authed)/grades/[index]/+page.svelte
+++ b/src/routes/(authed)/grades/[index]/+page.svelte
@@ -19,7 +19,6 @@
 		getHiddenAssignmentsFromCategories,
 		getPointsByCategory,
 		getPointsByCategoryMap,
-		getSynergyCourseAssignmentCategories,
 		gradesMatch,
 		type HiddenAssignment,
 		type NewHypotheticalAssignment,
@@ -28,6 +27,7 @@
 		type ReactiveAssignment,
 		type RealAssignment
 	} from '$lib/grades/assignments';
+	import { getSynergyCourseAssignmentCategories } from '$lib/grades/course';
 	import { getActiveGradebook } from '$lib/grades/gradebook';
 	import { saveSeenAssignmentsToLocalStorage } from '$lib/grades/seenAssignments';
 	import { seenAssignmentIDs } from '$lib/grades/seenAssignments.svelte';
@@ -51,7 +51,7 @@
 			: undefined
 	);
 
-	const mark = $derived(synergyCourse?.Marks !== '' ? synergyCourse?.Marks.Mark : undefined);
+	const mark = $derived(synergyCourse?.Marks?.Mark[0]);
 
 	const courseName = $derived(synergyCourse ? removeCourseType(synergyCourse._CourseName) : '');
 
@@ -63,7 +63,7 @@
 
 	const gradeCategories = $derived(categories?.filter((category) => category.name !== 'TOTAL'));
 
-	const synergyAssignments = $derived(mark?.Assignments.Assignment ?? []);
+	const synergyAssignments = $derived(mark?.Assignments?.Assignment ?? []);
 
 	const realAssignments = $derived(
 		calculateAssignmentGPCs(synergyAssignments.map(parseSynergyAssignment), gradeCategories)
@@ -165,7 +165,7 @@
 		reactiveAssignments = [newHypotheticalAssignment, ...reactiveAssignments];
 	}
 
-	const prefix = $derived(hypotheticalMode ? '' : mark?._CalculatedScoreString + ' ');
+	const prefix = $derived(hypotheticalMode ? '' : `${mark?._CalculatedScoreString} `);
 
 	const grade = $derived(
 		hypotheticalMode

--- a/src/routes/(authed)/grades/[index]/AssignmentCard.svelte
+++ b/src/routes/(authed)/grades/[index]/AssignmentCard.svelte
@@ -199,7 +199,13 @@
 			{/if}
 
 			{#if hidden}
-				<Badge variant="secondary" outline={true} class="hidden-badge">Hidden Assignments</Badge>
+				<Badge
+					variant="secondary"
+					outline={true}
+					title="There is a discrepancy between the points listed in the category and the sum of the points of the assignments in the category. This assignment has been generated to account for that discrepancy."
+				>
+					Point Discrepancy
+				</Badge>
 			{/if}
 
 			{#if unscaledPoints}

--- a/src/routes/(authed)/grades/[index]/AssignmentCard.svelte
+++ b/src/routes/(authed)/grades/[index]/AssignmentCard.svelte
@@ -12,10 +12,12 @@
 	import * as Select from '$lib/components/ui/select';
 	import { calculateGradePercentage } from '$lib/grades/assignments';
 	import MessageCircleIcon from '@lucide/svelte/icons/message-circle';
+	import TextAlignStartIcon from '@lucide/svelte/icons/text-align-start';
 
 	type Props = {
 		name: string;
 		id: string;
+		description?: string;
 		pointsEarned?: number;
 		pointsPossible?: number;
 		unscaledPoints?: { pointsEarned: number; pointsPossible: number };
@@ -45,6 +47,7 @@
 	let {
 		name = $bindable(),
 		id,
+		description,
 		pointsEarned = $bindable(),
 		pointsPossible = $bindable(),
 		unscaledPoints = $bindable(),
@@ -104,7 +107,7 @@
 	]}
 >
 	<div class="flex flex-1 flex-col gap-1 self-start sm:self-auto">
-		<div class="flex flex-wrap gap-1">
+		<div class="flex flex-wrap gap-1 items-center">
 			{#if editable}
 				<Input bind:value={name} class="inline w-32 sm:w-48" />
 
@@ -149,6 +152,18 @@
 				{/if}
 			{:else}
 				{name}
+			{/if}
+
+			{#if description && !editable}
+				<Popover.Root>
+					<Popover.Trigger
+						class={['ml-1', buttonVariants({ variant: 'outline', size: 'icon' })]}
+						title="Assignment description"
+					>
+						<TextAlignStartIcon />
+					</Popover.Trigger>
+					<Popover.Content>{description}</Popover.Content>
+				</Popover.Root>
 			{/if}
 		</div>
 

--- a/src/routes/(authed)/grades/[index]/AssignmentTabs.svelte
+++ b/src/routes/(authed)/grades/[index]/AssignmentTabs.svelte
@@ -190,9 +190,10 @@
 		notForGrade,
 		hidden,
 		category,
-		comments,
 		date,
-		newHypothetical
+		newHypothetical,
+		description,
+		comments
 	}: RealAssignment | Flowed<RealAssignment | HiddenAssignment>,
 	showCategory = true
 )}
@@ -200,6 +201,7 @@
 		<AssignmentCard
 			{name}
 			{id}
+			{description}
 			{pointsEarned}
 			{pointsPossible}
 			{unscaledPoints}

--- a/src/routes/(authed)/grades/[index]/AssignmentTabs.svelte
+++ b/src/routes/(authed)/grades/[index]/AssignmentTabs.svelte
@@ -213,7 +213,7 @@
 				: undefined}
 			{date}
 			{comments}
-			unseen={seenAssignmentIDs && !seenAssignmentIDs.has(id)}
+			unseen={seenAssignmentIDs && !seenAssignmentIDs.has(id) && !hidden}
 		/>
 	</li>
 {/snippet}

--- a/src/routes/privacy/+page.svelte
+++ b/src/routes/privacy/+page.svelte
@@ -19,20 +19,24 @@
 				<Card.Title>About the privacy of {brand}</Card.Title>
 			</Card.Header>
 
-			<Card.Content class="space-y-4">
+			<Card.Content class="text-tertiary-foreground space-y-4">
 				<p>
-					{brand} is designed to keep students' information private the entire time they use the service.
+					{brand} is designed to keep students' information private.
 				</p>
 
 				<p>
-					When a student uses {brand}, their own device sends their username and password directly
-					to the offical student portal, and the portal returns their student information directly
-					to their device. {brand} servers do not receive or process any student information. All student
-					information is stored and processed on-device.
+					When a student uses the {brand} interface, their own device transmits their username and password
+					directly to the official student portal, which returns their student information directly to
+					their device.
 				</p>
 
 				<p>
-					If you have questions or concerns about {brand}, please contact us at
+					{brand} servers do not receive any student data or login information. The GradeCompass interface
+					is purely client-side: all data is retrieved, processed, and stored on-device.
+				</p>
+
+				<p>
+					If you have questions or concerns about {brand}, you can contact us at
 					<a href="mailto:{email}" class="underline">{email}</a>.
 				</p>
 			</Card.Content>


### PR DESCRIPTION
Related to #161, #182, and #191

Currently the only first mark is considered. This is a temporary solution.

Also,
- Process empty xml content as null rather than '' to allow for ergonomic optional chaining (only applies to gradebook for now)
- Add JSDoc descriptions to gradebook types
- Refactor assignment edge cases documentation
- Rename "Hidden Assignment" to "Point Discrepancy" and don't show new badge
- Fix loading banner z-index on mobile
- Add privacy link in sidebar and rewrite privacy page
- Show assignment descriptions